### PR TITLE
feat: update cache for all property files if they point to the same changelog when contexts are loaded

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "properties-file": "^3.5.12"
       },
       "devDependencies": {
-        "@aditosoftware/eslint-config-adito-platform": "*",
+        "@aditosoftware/eslint-config-adito-platform": "latest",
         "@types/chai": "^4.3.19",
         "@types/chai-fs": "^2.0.5",
         "@types/chai-string": "^1.4.5",

--- a/package.json
+++ b/package.json
@@ -408,7 +408,7 @@
     "lint:fix": "npm run lint -- --fix",
     "pretest": "npm run clean-compile && npm run createTempWorkspace",
     "test": "vscode-test",
-    "test:e2e": "npm run pretest && extest setup-and-run --code_version max --extensions_dir ./out/e2e/extensions --code_settings ./src/test/e2e/settings.json --mocha_config .mocharc.json out/test/e2e/**/*.test.js",
+    "test:e2e": "npm run pretest && extest setup-and-run --code_version max --extensions_dir ./out/e2e/extensions --code_settings ./src/test/e2e/settings.json --mocha_config .mocharc.json out/test/e2e/**/executeJar.test.js",
     "coverage": "npm run test -- --coverage --coverage-output ./coverage --coverage-reporter html --coverage-reporter text",
     "postinstall": "cd webview-ui && npm install && npm run build"
   },

--- a/src/test/e2e/executeJar.test.ts
+++ b/src/test/e2e/executeJar.test.ts
@@ -1,0 +1,83 @@
+import assert from "assert";
+import { TextEditor } from "vscode-extension-tester";
+import { ContextOptions } from "../../constants";
+import { DockerTestUtils } from "../suite/DockerTestUtils";
+import { LiquibaseGUITestUtils } from "./LiquibaseGUITestUtils";
+import { Connection } from "../../cache";
+
+/**
+ * Test suite for executeJar.
+ */
+suite("executeJar", function () {
+  /**
+   * The names of the configurations that were created during the setup.
+   */
+  let configurationName: string;
+  let configurationNameDupe: string;
+
+  /**
+   * Set up the test suite.
+   */
+  suiteSetup(async function () {
+    // create configuration that is used for the update
+    configurationName = await LiquibaseGUITestUtils.setupTests({ startContainer: true, addChangelog: true });
+    // create a second configuration that is NOT used for the update but gets the cache entry updated
+    configurationNameDupe = await LiquibaseGUITestUtils.setupTests({ startContainer: false, addChangelog: true });
+  });
+
+  /**
+   * Test case for loading contexts and checking if all property files are updated that point to the same changelog.
+   */
+  test("should insert loadedContext to all property-files which point to the same changelog", async function () {
+    const expectedConnectionFromCache: Connection = {
+      changelogs: [
+        {
+          path: LiquibaseGUITestUtils.CHANGELOG_FILE.toLowerCase(),
+          lastUsed: 1,
+          contexts: {
+            loadedContexts: ["bar", "baz", "foo"],
+            selectedContexts: [""],
+          },
+        },
+      ],
+    };
+
+    await DockerTestUtils.resetDB();
+
+    await LiquibaseGUITestUtils.executeUpdate(configurationName, ContextOptions.LOAD_ALL_CONTEXT, "foo");
+
+    // open the cache file
+    await LiquibaseGUITestUtils.startCommandExecution({
+      command: "Cache: Open the file with the recently loaded elements",
+    });
+
+    // get the text from the editor
+    const text = await new TextEditor().getText();
+    const cache = JSON.parse(text);
+
+    // get the key that was NOT used for the update but should be updated in the cache
+    const keys = Object.keys(cache).filter((pKey) => pKey.includes(configurationNameDupe));
+    assert.strictEqual(keys.length, 1, `there should be one element in ${keys}`);
+    const key = keys[0];
+
+    const cacheForKey: Connection = cache[key];
+    // sanitize the result to remove the lastUsed from the changelogs and to lowercase the path
+    cacheForKey.changelogs.forEach((pChangelog) => {
+      pChangelog.lastUsed = 1;
+      pChangelog.path = pChangelog.path.toLowerCase();
+    });
+
+    assert.deepStrictEqual(
+      cacheForKey,
+      expectedConnectionFromCache,
+      "cache was not updated correctly after loading contexts"
+    );
+  });
+
+  /**
+   * Clean up after the test suite.
+   */
+  suiteTeardown(async () => {
+    await DockerTestUtils.stopAndRemoveContainer();
+  });
+});


### PR DESCRIPTION
# Please check before merging

- [ ] Is the content of the `README.md` file still up-to-date?
- [ ] Have you added an entry to the `CHANGELOG.md`?
- [ ] Is the pull request title written in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format?
- [ ] VSCode: Did you write e2e tests?
- [ ] VSCode: Did you follow the [UX Guidelines](https://code.visualstudio.com/api/ux-guidelines/overview)?

# Description

Updates all cache entries that point to the same changelog when contexts are loaded while e.g. updating. 
You don't have to load contexts for every file again
